### PR TITLE
Support TYPE_USE type Nullable annotations.

### DIFF
--- a/core/src/com/google/inject/spi/InjectionPoint.java
+++ b/core/src/com/google/inject/spi/InjectionPoint.java
@@ -36,6 +36,7 @@ import com.google.inject.internal.Nullability;
 import com.google.inject.internal.util.Classes;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
@@ -80,6 +81,7 @@ public final class InjectionPoint {
             new Errors(method),
             method,
             declaringType,
+            method.getAnnotatedParameterTypes(),
             method.getParameterAnnotations(),
             KotlinSupport.getInstance().getIsParameterKotlinNullablePredicate(method));
   }
@@ -96,6 +98,7 @@ public final class InjectionPoint {
             errors,
             constructor,
             declaringType,
+            constructor.getAnnotatedParameterTypes(),
             constructor.getParameterAnnotations(),
             KotlinSupport.getInstance().getIsParameterKotlinNullablePredicate(constructor));
   }
@@ -106,7 +109,7 @@ public final class InjectionPoint {
     this.optional = optional;
 
     Annotation[] annotations = getAnnotations(field);
-
+    Annotation[] typeUseAnnotations = field.getAnnotatedType().getAnnotations();
     Errors errors = new Errors(field);
     Key<?> key = null;
     try {
@@ -120,6 +123,7 @@ public final class InjectionPoint {
 
     boolean allowsNull =
         Nullability.hasNullableAnnotation(annotations)
+            || Nullability.hasNullableAnnotation(typeUseAnnotations)
             || KotlinSupport.getInstance().isNullable(field);
     this.dependencies = ImmutableList.<Dependency<?>>of(newDependency(key, allowsNull, -1));
   }
@@ -128,6 +132,7 @@ public final class InjectionPoint {
       Errors errors,
       Member member,
       TypeLiteral<?> type,
+      AnnotatedType[] annotatedTypes,
       Annotation[][] parameterAnnotationsPerParameter,
       Predicate<Integer> isParameterKotlinNullable) {
     List<Dependency<?>> dependencies = Lists.newArrayList();
@@ -135,10 +140,12 @@ public final class InjectionPoint {
 
     for (TypeLiteral<?> parameterType : type.getParameterTypes(member)) {
       try {
+        Annotation[] typeAnnotations = annotatedTypes[index].getAnnotations();
         Annotation[] parameterAnnotations = parameterAnnotationsPerParameter[index];
         Key<?> key = Annotations.getKey(parameterType, member, parameterAnnotations, errors);
         boolean isNullable =
             Nullability.hasNullableAnnotation(parameterAnnotations)
+                || Nullability.hasNullableAnnotation(typeAnnotations)
                 || isParameterKotlinNullable.test(index);
         dependencies.add(newDependency(key, isNullable, index));
         index++;

--- a/core/test/com/google/inject/NullableInjectionPointTest.java
+++ b/core/test/com/google/inject/NullableInjectionPointTest.java
@@ -1,6 +1,8 @@
 package com.google.inject;
 
 import static com.google.inject.Asserts.assertContains;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import com.google.common.base.Optional;
 import com.google.inject.multibindings.OptionalBinder;
@@ -89,6 +91,22 @@ public class NullableInjectionPointTest extends TestCase {
 
   public void testInjectNullIntoCustomNullableField() {
     CustomNullableFooField nff = createInjector().getInstance(CustomNullableFooField.class);
+    assertNull(nff.foo);
+  }
+
+  public void testInjectNullIntoTypeUseNullableConstructor() {
+    TypeUseNullableFooConstructor nff =
+        createInjector().getInstance(TypeUseNullableFooConstructor.class);
+    assertNull(nff.foo);
+  }
+
+  public void testInjectNullIntoTypeUseNullableMethod() {
+    TypeUseNullableFooMethod nfm = createInjector().getInstance(TypeUseNullableFooMethod.class);
+    assertNull(nfm.foo);
+  }
+
+  public void testInjectNullIntoTypeUseNullableField() {
+    TypeUseNullableFooField nff = createInjector().getInstance(TypeUseNullableFooField.class);
     assertNull(nff.foo);
   }
 
@@ -261,6 +279,34 @@ public class NullableInjectionPointTest extends TestCase {
 
     @Inject
     void setFoo(@Namespace.Nullable Foo foo) {
+      this.foo = foo;
+    }
+  }
+
+  private static class TypeUse {
+    @Retention(RUNTIME)
+    @Target(TYPE_USE)
+    private @interface Nullable {}
+  }
+
+  static class TypeUseNullableFooConstructor {
+    Foo foo;
+
+    @Inject
+    TypeUseNullableFooConstructor(@TypeUse.Nullable Foo foo) {
+      this.foo = foo;
+    }
+  }
+
+  static class TypeUseNullableFooField {
+    @Inject @TypeUse.Nullable Foo foo;
+  }
+
+  static class TypeUseNullableFooMethod {
+    Foo foo;
+
+    @Inject
+    void setFoo(@TypeUse.Nullable Foo foo) {
       this.foo = foo;
     }
   }

--- a/extensions/testlib/src/com/google/inject/testing/fieldbinder/BoundFieldModule.java
+++ b/extensions/testlib/src/com/google/inject/testing/fieldbinder/BoundFieldModule.java
@@ -350,6 +350,7 @@ public final class BoundFieldModule implements Module {
     private boolean allowsNull() {
       return !isTransparentProvider(fieldType.getRawType())
           && (Nullability.hasNullableAnnotation(field.getAnnotations())
+              || Nullability.hasNullableAnnotation(field.getAnnotatedType().getAnnotations())
               || KotlinSupport.getInstance().isNullable(field));
     }
   }

--- a/extensions/testlib/test/com/google/inject/testing/fieldbinder/BoundFieldModuleTest.java
+++ b/extensions/testlib/test/com/google/inject/testing/fieldbinder/BoundFieldModuleTest.java
@@ -462,14 +462,22 @@ public class BoundFieldModuleTest extends TestCase {
   @Retention(RUNTIME)
   private @interface Nullable {}
 
+  private static class TypeUse {
+    @Retention(RUNTIME)
+    @Target(TYPE_USE)
+    private @interface Nullable {}
+  }
+
   public void testBindingNullableNullField() {
     Object instance =
         new Object() {
           @Bind @Nullable private Integer anInt = null;
+          @Bind @TypeUse.Nullable private Long aLong = null;
         };
 
     Injector injector = Guice.createInjector(BoundFieldModule.of(instance));
     assertNull(injector.getInstance(Integer.class));
+    assertNull(injector.getInstance(Long.class));
   }
 
   public void testBindingNullProvider() {


### PR DESCRIPTION
This change only add support for top level annotation like `@Nullable List<String>` and not `List<@Nullable String>`.

PiperOrigin-RevId: 361592529